### PR TITLE
converter: Write out gem dependencies to metadata.rb

### DIFF
--- a/lib/halite/converter/metadata.rb
+++ b/lib/halite/converter/metadata.rb
@@ -47,6 +47,11 @@ module Halite
             buf << ", #{dep.requirement.inspect}" if dep.requirement != '>= 0'
             buf << "\n"
           end
+          gem_data.gem_dependencies.each do |dep|
+            buf << "gem #{dep.name.inspect}"
+            buf << ", #{dep.requirement.inspect}" if dep.requirement != '>= 0'
+            buf << "\n"
+          end
           buf << "chef_version #{(gem_data.spec.metadata['halite_chef_version'] || '~> 12').inspect} if defined?(chef_version)\n"
         end
       end

--- a/lib/halite/gem.rb
+++ b/lib/halite/gem.rb
@@ -157,12 +157,22 @@ module Halite
     end
 
     def cookbook_dependencies
-      @cookbook_dependencies ||= Dependencies.extract(spec)
+      @cookbook_dependencies ||= Dependencies.extract_cookbooks(spec)
+    end
+
+    # List gem dependencies.
+    def gem_dependencies
+      @gem_dependencies ||= Dependencies.extract_gems(spec)
     end
 
     # Is this gem really a cookbook? (anything that depends directly on halite and doesn't have the ignore flag)
     def is_halite_cookbook?
       spec.dependencies.any? {|subdep| subdep.name == 'halite'} && !spec.metadata.include?('halite_ignore')
+    end
+
+    # Is this gem halite itself? We don't want to add this as a gem dep.
+    def is_halite_gem?
+      spec.name == 'halite'
     end
 
     # Create a Chef::CookbookVersion object that represents this gem. This can

--- a/spec/dependencies_spec.rb
+++ b/spec/dependencies_spec.rb
@@ -80,9 +80,9 @@ describe Halite::Dependencies do
     end
   end # /describe #extract_from_metadata
 
-  describe '#extract_from_dependencies' do
+  describe '#extract_cookbooks_from_dependencies' do
     let(:gemspec) { }
-    subject { described_class.extract_from_dependencies(gemspec) }
+    subject { described_class.extract_cookbooks_from_dependencies(gemspec) }
 
     context 'with a halite-ish dependency' do
       let(:gemspec) { fake_gem {|s| s.add_dependency 'gem3' } }
@@ -98,7 +98,27 @@ describe Halite::Dependencies do
       let(:gemspec) { fake_gem {|s| s.add_development_dependency 'gem1' } }
       it { is_expected.to eq [] }
     end
-  end # /describe #extract_from_dependencies
+  end # /describe #extract_cookbooks_from_dependencies
+
+  describe '#extract_gems_from_dependencies' do
+    let(:gemspec) { }
+    subject { described_class.extract_gems_from_dependencies(gemspec) }
+
+    context 'with a halite-ish dependency' do
+      let(:gemspec) { fake_gem {|s| s.add_dependency 'gem3' } }
+      it { is_expected.to eq [] }
+    end
+
+    context 'with a development dependency' do
+      let(:gemspec) { fake_gem {|s| s.add_development_dependency 'gem3' } }
+      it { is_expected.to eq [] }
+    end
+
+    context 'with a non-halite runtime dependency' do
+      let(:gemspec) { fake_gem {|s| s.add_dependency 'gem1' } }
+      it { is_expected.to eq [['gem1', '>= 0', gem_stubs[0]]] }
+    end
+  end # /describe #extract_gems_from_dependencies
 
   describe '#clean' do
     let(:dependency) { nil }

--- a/spec/fixtures/cookbooks/test5/files/halite_gem/test3.rb
+++ b/spec/fixtures/cookbooks/test5/files/halite_gem/test3.rb
@@ -1,0 +1,4 @@
+require 'test5/dsl'
+
+module Test5
+end

--- a/spec/fixtures/cookbooks/test5/files/halite_gem/test5.rb
+++ b/spec/fixtures/cookbooks/test5/files/halite_gem/test5.rb
@@ -1,0 +1,4 @@
+require 'test5/dsl'
+
+module Test5
+end

--- a/spec/fixtures/cookbooks/test5/files/halite_gem/test5/dsl.rb
+++ b/spec/fixtures/cookbooks/test5/files/halite_gem/test5/dsl.rb
@@ -1,0 +1,15 @@
+require 'test2/version'
+
+module Test5
+  module DSL
+    def test5_method
+      "!!!!!!!!!!test5#{Test2::VERSION}"
+    end
+  end
+end
+
+class Chef
+  class Recipe
+    include Test5::DSL
+  end
+end

--- a/spec/fixtures/cookbooks/test5/files/halite_gem/test5/version.rb
+++ b/spec/fixtures/cookbooks/test5/files/halite_gem/test5/version.rb
@@ -1,0 +1,3 @@
+module Test5
+  VERSION = '7.8.9'
+end

--- a/spec/fixtures/cookbooks/test5/libraries/default.rb
+++ b/spec/fixtures/cookbooks/test5/libraries/default.rb
@@ -1,0 +1,4 @@
+# coding: utf-8
+raise 'Halite is not compatible with no_lazy_load false, please set no_lazy_load true in your Chef configuration file.' unless Chef::Config[:no_lazy_load]
+$LOAD_PATH << File.expand_path('../../files/halite_gem', __FILE__)
+require "test5/dsl"

--- a/spec/fixtures/cookbooks/test5/metadata.rb
+++ b/spec/fixtures/cookbooks/test5/metadata.rb
@@ -1,0 +1,10 @@
+# coding: utf-8
+name "test5"
+version "7.8.9"
+maintainer "Noah Kantrowitz"
+maintainer_email "noah@coderanger.net"
+source_url "http://example.com/" if defined?(source_url)
+license "Apache 2.0"
+depends "test2", "~> 4.5.6"
+gem "test6", "~> 10.11.12"
+chef_version "~> 12" if defined?(chef_version)

--- a/spec/fixtures/cookbooks/test5/recipes/default.rb
+++ b/spec/fixtures/cookbooks/test5/recipes/default.rb
@@ -1,0 +1,1 @@
+log test5_method

--- a/spec/fixtures/gems/test5/Rakefile
+++ b/spec/fixtures/gems/test5/Rakefile
@@ -1,0 +1,1 @@
+require 'halite/rake_tasks'

--- a/spec/fixtures/gems/test5/chef/recipes/default.rb
+++ b/spec/fixtures/gems/test5/chef/recipes/default.rb
@@ -1,0 +1,1 @@
+log test5_method

--- a/spec/fixtures/gems/test5/lib/test5.rb
+++ b/spec/fixtures/gems/test5/lib/test5.rb
@@ -1,0 +1,4 @@
+require 'test5/dsl'
+
+module Test5
+end

--- a/spec/fixtures/gems/test5/lib/test5/dsl.rb
+++ b/spec/fixtures/gems/test5/lib/test5/dsl.rb
@@ -1,0 +1,15 @@
+require 'test2/version'
+
+module Test5
+  module DSL
+    def test5_method
+      "!!!!!!!!!!test5#{Test2::VERSION}"
+    end
+  end
+end
+
+class Chef
+  class Recipe
+    include Test5::DSL
+  end
+end

--- a/spec/fixtures/gems/test5/lib/test5/version.rb
+++ b/spec/fixtures/gems/test5/lib/test5/version.rb
@@ -1,0 +1,3 @@
+module Test5
+  VERSION = '7.8.9'
+end

--- a/spec/fixtures/gems/test5/test5.gemspec
+++ b/spec/fixtures/gems/test5/test5.gemspec
@@ -1,0 +1,26 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'test5/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'test5'
+  spec.version = Test5::VERSION
+  spec.authors = ['Noah Kantrowitz']
+  spec.email = %w{noah@coderanger.net}
+  spec.description = %q||
+  spec.summary = %q||
+  spec.homepage = 'http://example.com/'
+  spec.license = 'Apache 2.0'
+  spec.metadata['halite_entry_point'] = 'test5/dsl'
+
+  spec.files = `cd #{File.expand_path('..', __FILE__)} && git ls-files`.split($/)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = %w{lib}
+
+  spec.add_dependency 'halite'
+  spec.add_dependency 'test2', '~> 4.5.6'
+  spec.add_dependency 'test6', '~> 10.11.12'
+  spec.add_development_dependency 'rake'
+end

--- a/spec/fixtures/gems/test6/Rakefile
+++ b/spec/fixtures/gems/test6/Rakefile
@@ -1,0 +1,1 @@
+require 'halite/rake_tasks'

--- a/spec/fixtures/gems/test6/lib/test6.rb
+++ b/spec/fixtures/gems/test6/lib/test6.rb
@@ -1,0 +1,4 @@
+require 'test6/dsl'
+
+module Test6
+end

--- a/spec/fixtures/gems/test6/lib/test6/dsl.rb
+++ b/spec/fixtures/gems/test6/lib/test6/dsl.rb
@@ -1,0 +1,15 @@
+require 'test2/version'
+
+module Test6
+  module DSL
+    def test6_method
+      "!!!!!!!!!!test6#{Test2::VERSION}"
+    end
+  end
+end
+
+class Chef
+  class Recipe
+    include Test6::DSL
+  end
+end

--- a/spec/fixtures/gems/test6/lib/test6/version.rb
+++ b/spec/fixtures/gems/test6/lib/test6/version.rb
@@ -1,0 +1,3 @@
+module Test6
+  VERSION = '10.11.12'
+end

--- a/spec/fixtures/gems/test6/test6.gemspec
+++ b/spec/fixtures/gems/test6/test6.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'test6/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'test6'
+  spec.version = Test6::VERSION
+  spec.authors = ['Noah Kantrowitz']
+  spec.email = %w{noah@coderanger.net}
+  spec.description = %q||
+  spec.summary = %q||
+  spec.homepage = 'http://example.com/'
+  spec.license = 'Apache 2.0'
+
+  spec.files = `cd #{File.expand_path('..', __FILE__)} && git ls-files`.split($/)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = %w{lib}
+
+  spec.add_development_dependency 'rake'
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -77,4 +77,11 @@ describe 'integration tests' do
     let(:expect_output) { '!!!!!!!!!!test34.5.6' }
     it_should_behave_like 'an integration test', 'test3', '7.8.9', [['testdep', '1.0.0']]
   end # /context with test3 gem
+
+  context 'with test5 gem', integration: true do
+    let(:extra_gems) { ['test2', 'test6'] }
+    let(:recipes) { ['test5'] }
+    let(:expect_output) { '!!!!!!!!!!test54.5.6' }
+    it_should_behave_like 'an integration test', 'test5', '7.8.9', [['testdep', '1.0.0']]
+  end # /context with test5 gem
 end


### PR DESCRIPTION
**NOTE**: Not too sure if it's a good idea to lock this into Chef >= 12.8.1 but I just thought I'd put it out there.

---
This update writes out non-cookbook gem dependencies as `gem`
dependencies in the cookbook's `metadata.rb` file.

This should enhance the Halite development experience, ensuring that the
cookbook developer can accurately assume that their dependencies will be
pulled in, instead of having to mess around with `chef_gem` or what not.

The gem dependency logic pulls in runtime dependencies only and skips
the `halite` gem itself.